### PR TITLE
Track Debian apt pins with the Renovate deb datasource

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,13 +26,18 @@
         "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
-      "datasourceTemplate": "repology",
-      "depNameTemplate": "debian_13/{{package}}"
+      "datasourceTemplate": "deb",
+      "depNameTemplate": "{{{package}}}"
     }
   ],
   "packageRules": [
     {
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
+      "registryUrls": [
+        "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
+        "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
       "automerge": true
     },
     {
@@ -73,15 +78,15 @@
     },
     {
       "groupName": "Python",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
       "automerge": true,
-      "matchDepNames": ["/^debian_*/python3.*/"]
+      "matchDepNames": ["/^python3.*/"]
     },
     {
       "groupName": "MariaDB",
-      "matchDatasources": ["repology"],
+      "matchDatasources": ["deb"],
       "automerge": true,
-      "matchDepNames": ["/^debian_*/libmariadb.*/"]
+      "matchDepNames": ["/^libmariadb.*/"]
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,6 @@
   "labels": ["dependencies", "no-stale"],
   "commitMessagePrefix": "⬆️",
   "commitMessageTopic": "{{depName}}",
-  "ignoreDeps": ["nodejs"],
   "customManagers": [
     {
       "customType": "regex",
@@ -37,6 +36,15 @@
         "https://deb.debian.org/debian?suite=trixie&components=main&binaryArch=amd64",
         "https://deb.debian.org/debian?suite=trixie-updates&components=main&binaryArch=amd64",
         "https://deb.debian.org/debian-security?suite=trixie-security&components=main&binaryArch=amd64"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "nodejs is pinned from the NodeSource repository, not Debian",
+      "matchDatasources": ["deb"],
+      "matchDepNames": ["nodejs"],
+      "registryUrls": [
+        "https://deb.nodesource.com/node_22.x?suite=nodistro&components=main&binaryArch=amd64"
       ],
       "automerge": true
     },


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Same change as hassio-addons/app-vaultwarden#447, applied here.

Repology has been unreliable as a datasource lately, and it forces us to map binary package names onto source package names. Renovate's native [`deb` datasource](https://docs.renovatebot.com/modules/datasource/deb/) reads the Debian package indices directly and indexes **binary** package names, so `depNameTemplate` becomes plain `{{{package}}}` and the mapping problem disappears.

The registry URLs are a one to one mirror of the apt sources in `ghcr.io/hassio-addons/debian-base:9.4.0`:

| Source | Suite | Component |
| --- | --- | --- |
| `deb.debian.org/debian` | `trixie` | `main` |
| `deb.debian.org/debian` | `trixie-updates` | `main` |
| `deb.debian.org/debian-security` | `trixie-security` | `main` |

Two extra bits beyond the Vaultwarden change, both specific to this repository:

- The **Python** and **MariaDB** grouping rules matched on `/^debian_*/python3.*/` and `/^debian_*/libmariadb.*/`. Those prefixes are gone with the new datasource, so the patterns become `/^python3.*/` and `/^libmariadb.*/`. Left as they were, both groups would have silently stopped matching.
- `ignoreDeps: ["nodejs"]` never actually matched anything before, because the dep was named `debian_13/nodejs` while the ignore was for a bare `nodejs`. It has been dead config since Renovate was introduced in #426. With bare names it would suddenly start working and silently freeze the pin, so instead of leaving it there, `nodejs` now gets a scoped registry of its own pointing at NodeSource. The `node_22.x` URL only ever serves 22.x, so it cannot jump a major.

### Known limitation

The datasource currently hardcodes `Packages.gz`, but `trixie-updates` and `trixie-security` serve only `Packages.xz`. Verified against the archive:

| Index | Status |
| --- | --- |
| `debian/dists/trixie/main/binary-amd64/Packages.gz` | 200 |
| `debian/dists/trixie-updates/main/binary-amd64/Packages.gz` | 404 |
| `debian-security/dists/trixie-security/main/binary-amd64/Packages.gz` | 404 |
| `debian/dists/trixie-updates/main/binary-amd64/Packages.xz` | 200 |
| `debian-security/dists/trixie-security/main/binary-amd64/Packages.xz` | 200 |

Those two suites are therefore inert for now. This fails gracefully: lookups are caught and skipped per component, so `trixie` `main` keeps working, and the other two start working by themselves once renovatebot/renovate#44330 is resolved. They are kept in the config so it stays a truthful description of what the image actually pulls from.

The practical impact here is larger than in Vaultwarden. Of the 33 Debian pins, 28 resolve from `trixie` `main` and keep updating as normal. Five come from `trixie-security` and will need a manual bump until the next point release folds them into `main`:

| Package | Pinned | `trixie` `main` has |
| --- | --- | --- |
| `libpq-dev` | `17.11-0+deb13u1` | `17.10-0+deb13u1` |
| `libpq5` | `17.11-0+deb13u1` | `17.10-0+deb13u1` |
| `libssl-dev` | `3.5.7-1~deb13u2` | `3.5.6-1~deb13u2` |
| `libtiff-dev` | `4.7.0-3+deb13u3` | `4.7.0-3+deb13u2` |
| `libtiff6` | `4.7.0-3+deb13u3` | `4.7.0-3+deb13u2` |

Since `main` only carries older versions for these five, Renovate has nothing to offer them and will not propose a downgrade, so the pins simply sit still rather than breaking the build.

### Verification

Beyond `renovate-config-validator`, this was run through an actual `renovate --platform=local --dry-run=lookup` on Renovate 44.50.3, which confirms the behaviour end to end:

- `trixie` `main` downloads and resolves; all 28 pins sourced from it are already current, so nothing spurious is proposed.
- `trixie-updates` and `trixie-security` return 404 on `Packages.gz` and are handled with `Skipping component due to an error`, exactly the graceful degradation described above.
- Before the NodeSource rule: `Dependency: nodejs, is ignored`, `skipReason: "ignored"`.
- After it: `nodejs` resolves against NodeSource and proposes `22.19.0-1nodesource1` to `22.23.2-1nodesource1` on `renovate/nodejs-22.x`, while the Debian lookups keep hitting only `deb.debian.org`.

`22.23.2-1nodesource1` is present for both `binary-amd64` and `binary-arm64`, so an automerged bump cannot break the aarch64 build.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Ports hassio-addons/app-vaultwarden#447 to this repository.

Upstream: renovatebot/renovate#44330

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/