### PR TITLE
Match Debian package names containing a dot or a plus

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -22,7 +22,7 @@
       "managerFilePatterns": ["//Dockerfile$/"],
       "matchStringsStrategy": "any",
       "matchStrings": [
-        "\\s\\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
+        "\\s\\s(?<package>[a-z0-9][a-z0-9+.-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\\s+"
       ],
       "versioningTemplate": "deb",
       "datasourceTemplate": "deb",


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The custom manager that picks up the apt pins only accepted `[a-z0-9-]` in a package name:

```
\s\s(?<package>[a-z0-9][a-z0-9-]+)=(?<currentValue>[a-z0-9-:_+~.]+)\s+
```

A period is not in that class, so `libxslt1.1` was silently never extracted, while `libxslt1-dev` was. Those two are pinned to the same version and have to move together. The moment Renovate bumped the `-dev` half on its own, apt would be handed an unsatisfiable pair and the build would fail on `Version ... was not found`, which is the same class of breakage that #776 had to clean up by hand.

[Debian policy][policy] allows lower case letters, digits, plus, minus and period in a binary package name, so the class now matches that: `[a-z0-9][a-z0-9+.-]+`. No pin currently uses a plus, but including it keeps the manager honest about what a legal package name looks like.

## Verification

Run through `renovate --platform=local --dry-run=extract` on Renovate 44.50.3, before and after, diffing the extracted dependency names. The change adds exactly one dependency and touches nothing else:

```
36a37
> libxslt1.1
```

That matters, because widening the class also exposes it to the `LABEL` block (`io.hass.version=`, `org.opencontainers.image.created=`, and friends) and to `numpy==2.4.4`. None of them match: the label values all start with `"` or `$`, which `currentValue` rejects, and `numpy` is preceded by a single space rather than the two the pattern needs.

A follow up `--dry-run=lookup` confirms the new dependency resolves properly rather than merely being extracted:

```json
{
  "depName": "libxslt1.1",
  "currentValue": "1.1.35-1.2+deb13u3",
  "datasource": "deb",
  "versioning": "deb",
  "updates": [],
  "sourceUrl": "https://gitlab.gnome.org/GNOME/libxslt/-/wikis/home"
}
```

No `skipReason`, a `sourceUrl` resolved out of the Debian index so the package was genuinely found, and an empty `updates` array because the pin is already current. It now sits alongside `libxslt1-dev` on the same `1.1.35-1.2+deb13u3`, and the two will be offered together from here on.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow up on #825, which switched these pins to the `deb` datasource. The same gap exists in hassio-addons/app-vaultwarden#447.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
[policy]: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
